### PR TITLE
fix(package): add useragent to be able to access webview

### DIFF
--- a/MetriportSDK.podspec
+++ b/MetriportSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MetriportSDK'
-  s.version          = '1.0.22'
+  s.version          = '1.0.23'
   s.summary          = 'A Swift Library for Metriport API and Apple Health integrations.'
 
   s.homepage         = 'https://github.com/metriport/metriport-ios-sdk'

--- a/Sources/MetriportSDK/MetriportWidget.swift
+++ b/Sources/MetriportSDK/MetriportWidget.swift
@@ -31,7 +31,7 @@ public struct MetriportWidget: UIViewRepresentable, WebViewHandlerDelegate {
         providers: [String]? = nil,
         url: String? = nil) {
             let config = WKWebViewConfiguration()
-
+            config.applicationNameForUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3 Mobile/15E148 Safari/604.1"
             let webView = WKWebView(frame: .zero, configuration: config)
 
             self.webView = webView

--- a/Sources/MetriportSDK/MetriportWidget.swift
+++ b/Sources/MetriportSDK/MetriportWidget.swift
@@ -31,7 +31,7 @@ public struct MetriportWidget: UIViewRepresentable, WebViewHandlerDelegate {
         providers: [String]? = nil,
         url: String? = nil) {
             let config = WKWebViewConfiguration()
-            config.applicationNameForUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3 Mobile/15E148 Safari/604.1"
+            config.applicationNameForUserAgent = "Safari"
             let webView = WKWebView(frame: .zero, configuration: config)
 
             self.webView = webView


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

https://metriport.slack.com/archives/C05DHBZ3VGV/p1689586364356559 

Customer was having issue with rendering google connect in widget, the issue was resolved by adding a user agent that google was familiar with