### PR TITLE
feat(package): handle so if user does not select and then does we rec…

### DIFF
--- a/MetriportSDK.podspec
+++ b/MetriportSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MetriportSDK'
-  s.version          = '1.0.23'
+  s.version          = '1.0.25'
   s.summary          = 'A Swift Library for Metriport API and Apple Health integrations.'
 
   s.homepage         = 'https://github.com/metriport/metriport-ios-sdk'


### PR DESCRIPTION
Ref. metriport/metriport#799

Handle the scenario that if a user chooses no types when prompted but then changes the type after in their settings we retrieve their historical data (if it wasnt queried) and then start listening for new events