### PR TITLE
fix(packages): add more logs - update start date - fix historical queries

### DIFF
--- a/MetriportSDK.podspec
+++ b/MetriportSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MetriportSDK'
-  s.version          = '1.0.25'
+  s.version          = '1.0.27'
   s.summary          = 'A Swift Library for Metriport API and Apple Health integrations.'
 
   s.homepage         = 'https://github.com/metriport/metriport-ios-sdk'


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

- Adding more logs to track errors
- Hourly had a bug where the startdate was always the same 
    - Didn't affect cx's because the start date was always before the data being added
 - Historical bug where if certain fields were missing data it wouldnt send 