### PR TITLE
fix(package): update historical to only send data when available and logs

### DIFF
--- a/MetriportSDK.podspec
+++ b/MetriportSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MetriportSDK'
-  s.version          = '1.0.27'
+  s.version          = '1.0.28'
   s.summary          = 'A Swift Library for Metriport API and Apple Health integrations.'
 
   s.homepage         = 'https://github.com/metriport/metriport-ios-sdk'

--- a/Sources/MetriportSDK/MetriportClient.swift
+++ b/Sources/MetriportSDK/MetriportClient.swift
@@ -170,11 +170,7 @@ extension SampleOrWorkout: Codable {
           healthStore?.enableBackgroundDelivery(for: sampleType, frequency: .immediate) { (success, failure) in
           guard failure == nil && success else {
 
-              metriportApi?.sendError(
-                metriportUserId: metriportUserId,
-                error: "Error enabling background delivery",
-                extra: ["sample": "\(sampleType)", "desc": "\(failure.debugDescription)"]
-              )
+              metriportApi?.sendError(metriportUserId: metriportUserId, error: "Error enabling background delivery", extra: ["sample": "\(sampleType)", "desc": "\(failure.debugDescription)"])
             return
           }
         }
@@ -246,7 +242,7 @@ extension SampleOrWorkout: Codable {
         query.initialResultsHandler = {
             query, results, error in
             if error != nil {
-                metriportApi?.sendError(metriportUserId: metriportUserId, error: "historical statisticsInitHandler", extra: ["type": "\(type)", "error": "\(error.debugDescription)"])
+                metriportApi?.sendError(metriportUserId: metriportUserId, error: "historical statisticsInitHandler", extra: ["type": "\(type)", "message": "\(error.debugDescription)"])
             }
 
             if UserDefaults.standard.object(forKey: "date \(type)") == nil {
@@ -257,7 +253,7 @@ extension SampleOrWorkout: Codable {
         query.statisticsUpdateHandler = {
             query, statistics, statisticsCollection, error in
             if error != nil {
-                metriportApi?.sendError(metriportUserId: metriportUserId, error: "historical statisticsUpdateHandler", extra: ["type": "\(type)", "error": "\(error.debugDescription)"])
+                metriportApi?.sendError(metriportUserId: metriportUserId, error: "historical statisticsUpdateHandler", extra: ["type": "\(type)", "message": "\(error.debugDescription)"])
             }
 
             if UserDefaults.standard.object(forKey: "date \(type)") == nil {
@@ -283,7 +279,11 @@ extension SampleOrWorkout: Codable {
                                                    startDate: startDate,
                                                    endDate: endDate,
                                                    queryOption: queryOption) else {
-                metriportApi?.sendError(metriportUserId: metriportUserId, error: "Error unable to handle historical statistics ", extra: ["type": "\(type)", "start": "\(startDate)", "end": "\(endDate)"])
+                metriportApi?.sendError(
+                    metriportUserId: metriportUserId,
+                    error: "Error unable to handle historical statistics ",
+                    extra: ["type": "\(type)", "start": "\(startDate)", "end": "\(endDate)"]
+                )
                 return
             }
 
@@ -327,7 +327,7 @@ extension SampleOrWorkout: Codable {
             query, statistics, statisticsCollection, error in
 
             if error != nil {
-                metriportApi?.sendError(metriportUserId: metriportUserId, error: "hourly statisticsUpdateHandler", extra: ["type": "\(type)", "error": "\(error.debugDescription)"])
+                metriportApi?.sendError(metriportUserId: metriportUserId, error: "blah blah blah", extra: ["type": "\(type)", "message": "\(error.debugDescription)"])
             }
 
             let calendar = Calendar.current

--- a/Sources/MetriportSDK/MetriportClient.swift
+++ b/Sources/MetriportSDK/MetriportClient.swift
@@ -170,7 +170,11 @@ extension SampleOrWorkout: Codable {
           healthStore?.enableBackgroundDelivery(for: sampleType, frequency: .immediate) { (success, failure) in
           guard failure == nil && success else {
 
-            metriportApi?.sendError(metriportUserId: metriportUserId, error: "Error enabling background delivery sample: \(sampleType) failure: \(failure.debugDescription)")
+              metriportApi?.sendError(
+                metriportUserId: metriportUserId,
+                error: "Error enabling background delivery",
+                extra: ["sample": "\(sampleType)", "desc": "\(failure.debugDescription)"]
+              )
             return
           }
         }
@@ -242,7 +246,7 @@ extension SampleOrWorkout: Codable {
         query.initialResultsHandler = {
             query, results, error in
             if error != nil {
-                metriportApi?.sendError(metriportUserId: metriportUserId, error: "historical statisticsInitHandler type: \(type) error: \(error.debugDescription)")
+                metriportApi?.sendError(metriportUserId: metriportUserId, error: "historical statisticsInitHandler", extra: ["type": "\(type)", "error": "\(error.debugDescription)"])
             }
 
             if UserDefaults.standard.object(forKey: "date \(type)") == nil {
@@ -253,7 +257,7 @@ extension SampleOrWorkout: Codable {
         query.statisticsUpdateHandler = {
             query, statistics, statisticsCollection, error in
             if error != nil {
-                metriportApi?.sendError(metriportUserId: metriportUserId, error: "historical statisticsUpdateHandler type: \(type) error: \(error.debugDescription)")
+                metriportApi?.sendError(metriportUserId: metriportUserId, error: "historical statisticsUpdateHandler", extra: ["type": "\(type)", "error": "\(error.debugDescription)"])
             }
 
             if UserDefaults.standard.object(forKey: "date \(type)") == nil {
@@ -279,7 +283,7 @@ extension SampleOrWorkout: Codable {
                                                    startDate: startDate,
                                                    endDate: endDate,
                                                    queryOption: queryOption) else {
-                metriportApi?.sendError(metriportUserId: metriportUserId, error: "Error unable to handle historical statistics type: \(type) start: \(startDate) end: \(endDate)")
+                metriportApi?.sendError(metriportUserId: metriportUserId, error: "Error unable to handle historical statistics ", extra: ["type": "\(type)", "start": "\(startDate)", "end": "\(endDate)"])
                 return
             }
 
@@ -323,7 +327,7 @@ extension SampleOrWorkout: Codable {
             query, statistics, statisticsCollection, error in
 
             if error != nil {
-                metriportApi?.sendError(metriportUserId: metriportUserId, error: "hourly statisticsUpdateHandler type: \(type) error: \(error.debugDescription)")
+                metriportApi?.sendError(metriportUserId: metriportUserId, error: "hourly statisticsUpdateHandler", extra: ["type": "\(type)", "error": "\(error.debugDescription)"])
             }
 
             let calendar = Calendar.current
@@ -348,7 +352,7 @@ extension SampleOrWorkout: Codable {
                                                            startDate: startDate,
                                                            endDate: endDate,
                                                            queryOption: queryOption) else {
-                        metriportApi?.sendError(metriportUserId: metriportUserId, error: "Error unable to handle hourly statistics type: \(type) unit: \(unit) start: \(startDate) end: \(endDate)")
+                        metriportApi?.sendError(metriportUserId: metriportUserId, error: "Error unable to handle hourly statistics", extra: ["type": "\(type)", "unit": "\(unit)", "start": "\(startDate)", "end": "\(endDate)"])
                         return
                     }
 

--- a/Sources/MetriportSDK/MetriportClient.swift
+++ b/Sources/MetriportSDK/MetriportClient.swift
@@ -327,7 +327,7 @@ extension SampleOrWorkout: Codable {
             query, statistics, statisticsCollection, error in
 
             if error != nil {
-                metriportApi?.sendError(metriportUserId: metriportUserId, error: "blah blah blah", extra: ["type": "\(type)", "message": "\(error.debugDescription)"])
+                metriportApi?.sendError(metriportUserId: metriportUserId, error: "statisticsUpdateHandler error", extra: ["type": "\(type)", "message": "\(error.debugDescription)"])
             }
 
             let calendar = Calendar.current


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ref: 799

### Dependencies

- Upstream: https://github.com/metriport/metriport/compare/799-allow-extra-apple-sentry?expand=1

### Description

Update the package to fix historical query issue where empty data was getting sent and add more descriptive logs

Remove unecessary prints, mostly used for Kodda and we dont have access to them

### Release Plan

- [ ] Upstream dependencies are met
- [ ] Merge once approved
- [ ] Deploy Pod